### PR TITLE
Feature/autocomplete input

### DIFF
--- a/components/common/expandableSearchGrid.tsx
+++ b/components/common/expandableSearchGrid.tsx
@@ -46,12 +46,13 @@ export const ExpandableSearchGrid = () => {
         />
       ))}
       {searchTerms.length < 3 ? (
-        <Card className="bg-secondary" sx={{ borderRadius: 0 }}>
+        <Card className="bg-primary-light" sx={{ borderRadius: 0 }}>
           <CardContent
             sx={{
               display: 'flex',
               flexDirection: 'column',
-              justifyContent: 'space-around',
+              justifyContent: 'center',
+              alignItems: 'center',
             }}
           >
             <SearchBar

--- a/components/common/expandableSearchGrid.tsx
+++ b/components/common/expandableSearchGrid.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { SearchTermCard } from './searchTermCard';
+import Card from '@mui/material/Card';
+import { CardContent } from '@mui/material';
+import { SearchBar } from './searchBar';
+
+interface Film {
+  title: string;
+  year: number;
+}
+
+export const ExpandableSearchGrid = () => {
+  const [value, setValue] = useState<Film[] | undefined>([]);
+  const [searchTerms, setSearchTerms] = useState<string[]>([]);
+  const [searchDisabled, setSearchDisable] = useState<boolean>(false);
+
+  function addSearchTerm(newSearchTerm: string) {
+    console.log('adding ' + newSearchTerm + ' to the search terms.');
+    setSearchTerms([...searchTerms, newSearchTerm]);
+  }
+
+  function deleteSearchTerm(searchTerm: string) {
+    console.log('deleteSearchTerm called on ' + searchTerm);
+    setSearchTerms(searchTerms.filter((item) => item !== searchTerm));
+    setValue(value?.filter((item) => item.title !== searchTerm));
+  }
+
+  useEffect(() => {
+    // console.log("The searchTerms have updated to ", searchTerms);
+    if (searchTerms.length >= 3) {
+      setSearchDisable(true);
+    } else {
+      setSearchDisable(false);
+    }
+  }, [searchTerms]);
+
+  return (
+    <div className="w-full min-h-[75px] grid grid-flow-row auto-cols-fr md:grid-flow-col justify-center">
+      {searchTerms.map((option: string, index: number) => (
+        <SearchTermCard
+          initialValue={option}
+          key={option}
+          index={index}
+          color={colors[index]}
+          onCloseButtonClicked={deleteSearchTerm}
+        />
+      ))}
+      {searchTerms.length < 3 ? (
+        <Card className="bg-secondary" sx={{ borderRadius: 0 }}>
+          <CardContent
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'space-around',
+            }}
+          >
+            <SearchBar
+              selectSearchValue={addSearchTerm}
+              value={value}
+              setValue={setValue}
+              disabled={searchDisabled}
+            />
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  );
+};
+
+const colors = ['#b71c1c', '#0d47a1', '#1b5e20'];

--- a/components/common/expandableSearchGrid.tsx
+++ b/components/common/expandableSearchGrid.tsx
@@ -9,6 +9,11 @@ interface Film {
   year: number;
 }
 
+/**
+ * This component returns a bar that will allow users to add and remove search terms (up to 3 max)
+ * using the SearchBar component. The currently selected search terms are represented by
+ * SearchTermCard components, and are displayed from left to right in this grid.
+ */
 export const ExpandableSearchGrid = () => {
   const [value, setValue] = useState<Film[] | undefined>([]);
   const [searchTerms, setSearchTerms] = useState<string[]>([]);
@@ -26,7 +31,6 @@ export const ExpandableSearchGrid = () => {
   }
 
   useEffect(() => {
-    // console.log("The searchTerms have updated to ", searchTerms);
     if (searchTerms.length >= 3) {
       setSearchDisable(true);
     } else {
@@ -41,7 +45,7 @@ export const ExpandableSearchGrid = () => {
           initialValue={option}
           key={option}
           index={index}
-          color={colors[index]}
+          legendColor={colors[index]}
           onCloseButtonClicked={deleteSearchTerm}
         />
       ))}

--- a/components/common/searchBar.tsx
+++ b/components/common/searchBar.tsx
@@ -1,35 +1,130 @@
-import { SearchIcon } from './searchIcon';
 import * as React from 'react';
-import { withStyles } from '@mui/material';
-import { SvgIcon } from '@mui/material';
+import { SearchIcon } from './searchIcon';
+import Autocomplete from '@mui/material/Autocomplete';
+import { throttle } from 'lodash';
+import topFilms from '../../data/autocomplete_dummy_data.json';
 
 /**
  * Props type used by the SearchBar component
-*/
+ */
 type SearchProps = {
   // setSearch: the setter function from the parent component to set the search value
   setSearch: Function;
 };
 
+interface Film {
+  title: string;
+  year: number;
+}
+
 /**
  * This component returns a custom search bar component that makes use of the Search Icon component
- * Sends the input value to the parent component on 'Enter' 
-*/
+ * Sends the input value to the parent component on 'Enter'
+ */
 export const SearchBar = (props: SearchProps) => {
+  const [open, setOpen] = React.useState(false);
+  const [options, setOptions] = React.useState<readonly Film[]>([]);
+  const loading = open && options.length === 0;
+
+  const [value, setValue] = React.useState<Film | null>(null);
+  const [inputValue, setInputValue] = React.useState('');
+
+  const fetch = React.useMemo(
+    () =>
+      throttle(
+        (
+          request: { input: string },
+          callback: (results?: readonly Film[]) => void,
+        ) => {
+          console.log('"called" the api again');
+        },
+        2000,
+      ),
+    [],
+  );
+
+  React.useEffect(() => {
+    let active = true;
+
+    (async () => {
+      fetch({ input: inputValue }, (results?: readonly Film[]) => {
+        if (active) {
+          let newOptions: readonly Film[] = [];
+
+          if (value) {
+            newOptions = [value];
+          }
+
+          if (results) {
+            newOptions = [...newOptions, ...results];
+          }
+
+          setOptions(newOptions);
+        }
+      });
+
+      if (active) {
+        console.log('options updated');
+        setOptions([...topFilms]);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [value, inputValue, fetch]);
+
+  React.useEffect(() => {
+    if (!open) {
+      setOptions([]);
+    }
+  }, [open]);
+
   return (
     <>
       <div className=" text-primary m-auto w-11/12 -translate-y-1/2">
         <div className="translate-y-10 translate-x-4 w-8 h-8">
           <SearchIcon />
         </div>
-        <input
-          type="search"
-          id="mainSearch"
-          className="rounded-md border-primary-dark border-2 w-full h-12 pl-12 bg-white text-primary-dark placeholder-primary-dark font-bold"
-          placeholder="Search section number, professor name, course number...."
-          onKeyPress={(e) =>
-            e.key === 'Enter' && props.setSearch(e.currentTarget.value)
-          }
+        <Autocomplete
+          className="w-full h-12 text-primary-dark placeholder-primary-dark font-bold"
+          sx={{
+            display: 'inline-block',
+            '& input': {},
+          }}
+          open={open}
+          onOpen={() => {
+            setOpen(true);
+          }}
+          onClose={() => {
+            setOpen(false);
+          }}
+          isOptionEqualToValue={(option, value) => option.title === value.title}
+          getOptionLabel={(option) => option.title}
+          options={options}
+          loading={loading}
+          value={value}
+          onChange={(event: any, newValue: Film | null) => {
+            setValue(newValue);
+          }}
+          inputValue={inputValue}
+          onInputChange={(event, newInputValue) => {
+            setInputValue(newInputValue);
+          }}
+          renderInput={(params) => (
+            <div ref={params.InputProps.ref}>
+              <input
+                {...params.inputProps}
+                type="search"
+                id="mainSearch"
+                className="rounded-md border-primary-dark border-2 w-full h-12 pl-12 bg-white text-primary-dark placeholder-primary-dark font-bold"
+                placeholder="Search section number, professor name, course number...."
+                onKeyPress={(e) =>
+                  e.key === 'Enter' && props.setSearch(e.currentTarget.value)
+                }
+              />
+            </div>
+          )}
         />
       </div>
     </>

--- a/components/common/searchBar.tsx
+++ b/components/common/searchBar.tsx
@@ -17,14 +17,19 @@ type SearchProps = {
   disabled?: boolean;
 };
 
+/**
+ * Data type used by the dummy data
+ */
 interface Film {
   title: string;
   year: number;
 }
 
 /**
- * This component returns a custom search bar component that makes use of the Search Icon component
- * Sends the input value to the parent component on 'Enter'
+ * This component returns a custom search bar component that makes use of the Material UI autocomplete component
+ * Sends a new search value to the parent component when the user selects it from the options list
+ *
+ * Styled for the ExpandableSearchGrid component
  */
 export const SearchBar = (props: SearchProps) => {
   const [open, setOpen] = React.useState(false);
@@ -102,25 +107,26 @@ export const SearchBar = (props: SearchProps) => {
           options={options}
           loading={loading}
           value={props.value}
+          // When a new option is selected, find the new selected option by getting the
+          // difference between the current and new value, then return that to the parent
+          // component using selectSearchValue prop
           onChange={(event: any, newValue: Film[] | undefined) => {
-            let intersection: Film[];
+            let difference: Film[];
             if (props.value !== undefined) {
               if (newValue !== undefined) {
                 // @ts-ignore
-                intersection = newValue.filter((x) => !props.value.includes(x));
+                difference = newValue.filter((x) => !props.value.includes(x));
               } else {
-                intersection = [];
+                difference = [];
               }
             } else {
               if (newValue !== undefined) {
-                intersection = newValue;
+                difference = newValue;
               } else {
-                intersection = [];
+                difference = [];
               }
             }
-            props.selectSearchValue(
-              intersection[0] ? intersection[0].title : '',
-            );
+            props.selectSearchValue(difference[0] ? difference[0].title : '');
             props.setValue(newValue);
           }}
           inputValue={inputValue}

--- a/components/common/searchBar.tsx
+++ b/components/common/searchBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { SearchIcon } from './searchIcon';
 import Autocomplete from '@mui/material/Autocomplete';
-import { throttle } from 'lodash';
+import throttle from 'lodash/throttle';
 import topFilms from '../../data/autocomplete_dummy_data.json';
 import Popper from '@mui/material/Popper';
 import { Box, Paper } from '@mui/material';
@@ -103,13 +103,21 @@ export const SearchBar = (props: SearchProps) => {
           loading={loading}
           value={props.value}
           onChange={(event: any, newValue: Film[] | undefined) => {
-            let intersection = props.value
-              ? newValue
-                ? newValue.filter((x) => !props.value.includes(x))
-                : []
-              : newValue
-              ? newValue
-              : [];
+            let intersection: Film[];
+            if (props.value !== undefined) {
+              if (newValue !== undefined) {
+                // @ts-ignore
+                intersection = newValue.filter((x) => !props.value.includes(x));
+              } else {
+                intersection = [];
+              }
+            } else {
+              if (newValue !== undefined) {
+                intersection = newValue;
+              } else {
+                intersection = [];
+              }
+            }
             props.selectSearchValue(
               intersection[0] ? intersection[0].title : '',
             );

--- a/components/common/searchBar.tsx
+++ b/components/common/searchBar.tsx
@@ -9,7 +9,10 @@ import topFilms from '../../data/autocomplete_dummy_data.json';
  */
 type SearchProps = {
   // setSearch: the setter function from the parent component to set the search value
-  setSearch: Function;
+  selectSearchValue: Function;
+  value: Film[] | undefined;
+  setValue: Function;
+  disabled?: boolean;
 };
 
 interface Film {
@@ -26,7 +29,6 @@ export const SearchBar = (props: SearchProps) => {
   const [options, setOptions] = React.useState<readonly Film[]>([]);
   const loading = open && options.length === 0;
 
-  const [value, setValue] = React.useState<Film | null>(null);
   const [inputValue, setInputValue] = React.useState('');
 
   const fetch = React.useMemo(
@@ -51,10 +53,6 @@ export const SearchBar = (props: SearchProps) => {
         if (active) {
           let newOptions: readonly Film[] = [];
 
-          if (value) {
-            newOptions = [value];
-          }
-
           if (results) {
             newOptions = [...newOptions, ...results];
           }
@@ -72,7 +70,7 @@ export const SearchBar = (props: SearchProps) => {
     return () => {
       active = false;
     };
-  }, [value, inputValue, fetch]);
+  }, [props.value, inputValue, fetch]);
 
   React.useEffect(() => {
     if (!open) {
@@ -87,11 +85,13 @@ export const SearchBar = (props: SearchProps) => {
           <SearchIcon />
         </div>
         <Autocomplete
-          className="w-full h-12 text-primary-dark placeholder-primary-dark font-bold"
-          sx={{
-            display: 'inline-block',
-            '& input': {},
-          }}
+          multiple={true}
+          disabled={props.disabled}
+          className="w-full h-12"
+          // sx={{
+          //   display: 'inline-block',
+          //   '& input': {},
+          // }}
           open={open}
           onOpen={() => {
             setOpen(true);
@@ -99,13 +99,23 @@ export const SearchBar = (props: SearchProps) => {
           onClose={() => {
             setOpen(false);
           }}
-          isOptionEqualToValue={(option, value) => option.title === value.title}
+          filterSelectedOptions
           getOptionLabel={(option) => option.title}
           options={options}
           loading={loading}
-          value={value}
-          onChange={(event: any, newValue: Film | null) => {
-            setValue(newValue);
+          value={props.value}
+          onChange={(event: any, newValue: Film[] | undefined) => {
+            // @ts-ignore
+            let intersection = props.value
+              ? newValue
+                ? newValue.filter((x) => !props.value.includes(x))
+                : []
+              : newValue
+              ? newValue
+              : [];
+            props.selectSearchValue(intersection[0].title);
+            // props.selectSearchValue("testing");
+            props.setValue(newValue);
           }}
           inputValue={inputValue}
           onInputChange={(event, newInputValue) => {
@@ -119,14 +129,19 @@ export const SearchBar = (props: SearchProps) => {
                 id="mainSearch"
                 className="rounded-md border-primary-dark border-2 w-full h-12 pl-12 bg-white text-primary-dark placeholder-primary-dark font-bold"
                 placeholder="Search section number, professor name, course number...."
-                onKeyPress={(e) =>
-                  e.key === 'Enter' && props.setSearch(e.currentTarget.value)
-                }
+                // onKeyPress={(e) =>
+                //   e.key === 'Enter' && props.setSearch(e.currentTarget.value)
+                // }
               />
             </div>
           )}
+          defaultValue={[]}
         />
       </div>
     </>
   );
+};
+
+SearchBar.defaultProps = {
+  disabled: true,
 };

--- a/components/common/searchIcon.tsx
+++ b/components/common/searchIcon.tsx
@@ -3,8 +3,8 @@
  *
  * This component simply returns the source of the svg so that it can be manipulated directly in
  * the DOM rather than using an IMG tag. Change color of the svg by changing the text color of the
- * surrouding div.
-*/
+ * surrounding div.
+ */
 export const SearchIcon = () => {
   return (
     <>

--- a/components/common/searchTermCard.tsx
+++ b/components/common/searchTermCard.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import Card from '@mui/material/Card';
+import { Box, IconButton, Typography } from '@mui/material';
+import { Close } from '@mui/icons-material';
+
+type SearchTermCardProps = {
+  initialValue: string;
+  index: number;
+  onCloseButtonClicked: Function;
+  color: string;
+};
+
+export const SearchTermCard = (props: SearchTermCardProps) => {
+  function handleClick() {
+    props.onCloseButtonClicked(props.initialValue);
+  }
+
+  return (
+    <Card
+      className="bg-secondary"
+      sx={{
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        borderRadius: 0,
+      }}
+    >
+      <div className="float-left flex align-middle place-items-center">
+        <Box
+          sx={{
+            backgroundColor: props.color,
+            borderRadius: 100,
+            width: '20px',
+            height: '20px',
+            float: 'left',
+            marginRight: '8px',
+            marginLeft: '8px',
+          }}
+        />
+        <Typography component="div" variant="h5" sx={{ float: 'right' }}>
+          {props.initialValue}
+        </Typography>
+      </div>
+      <div className="float-right">
+        <IconButton aria-label="play/pause" onClick={handleClick}>
+          <Close />
+        </IconButton>
+      </div>
+    </Card>
+  );
+};

--- a/components/common/searchTermCard.tsx
+++ b/components/common/searchTermCard.tsx
@@ -17,7 +17,7 @@ export const SearchTermCard = (props: SearchTermCardProps) => {
 
   return (
     <Card
-      className="bg-secondary"
+      className="bg-primary-light"
       sx={{
         display: 'flex',
         flexDirection: 'row',

--- a/components/common/searchTermCard.tsx
+++ b/components/common/searchTermCard.tsx
@@ -3,15 +3,23 @@ import Card from '@mui/material/Card';
 import { Box, IconButton, Typography } from '@mui/material';
 import { Close } from '@mui/icons-material';
 
+/**
+ * Props type used by the SearchTermCard component
+ */
 type SearchTermCardProps = {
   initialValue: string;
   index: number;
   onCloseButtonClicked: Function;
-  color: string;
+  legendColor: string;
 };
 
+/**
+ * This component returns a custom Card that shows the search term and a colored circle
+ * next to it representing the corresponding data's color
+ *
+ */
 export const SearchTermCard = (props: SearchTermCardProps) => {
-  function handleClick() {
+  function handleCloseClick() {
     props.onCloseButtonClicked(props.initialValue);
   }
 
@@ -29,7 +37,7 @@ export const SearchTermCard = (props: SearchTermCardProps) => {
       <div className="float-left flex align-middle place-items-center">
         <Box
           sx={{
-            backgroundColor: props.color,
+            backgroundColor: props.legendColor,
             borderRadius: 100,
             width: '20px',
             height: '20px',
@@ -43,7 +51,7 @@ export const SearchTermCard = (props: SearchTermCardProps) => {
         </Typography>
       </div>
       <div className="float-right">
-        <IconButton aria-label="play/pause" onClick={handleClick}>
+        <IconButton aria-label="play/pause" onClick={handleCloseClick}>
           <Close />
         </IconButton>
       </div>

--- a/components/common/splashPageSearchBar.tsx
+++ b/components/common/splashPageSearchBar.tsx
@@ -21,8 +21,10 @@ interface Film {
 }
 
 /**
- * This component returns a custom search bar component that makes use of the Search Icon component
- * Sends the input value to the parent component on 'Enter'
+ * This component returns a custom search bar component that makes use of the Material UI autocomplete component
+ * Sends a new search value to the parent component when the user selects it from the options list
+ *
+ * Styled for the splash page
  */
 export const SplashPageSearchBar = (props: SearchProps) => {
   const [open, setOpen] = React.useState(false);

--- a/components/common/splashPageSearchBar.tsx
+++ b/components/common/splashPageSearchBar.tsx
@@ -3,8 +3,6 @@ import { SearchIcon } from './searchIcon';
 import Autocomplete from '@mui/material/Autocomplete';
 import { throttle } from 'lodash';
 import topFilms from '../../data/autocomplete_dummy_data.json';
-import Popper from '@mui/material/Popper';
-import { Box, Paper } from '@mui/material';
 
 /**
  * Props type used by the SearchBar component
@@ -26,7 +24,7 @@ interface Film {
  * This component returns a custom search bar component that makes use of the Search Icon component
  * Sends the input value to the parent component on 'Enter'
  */
-export const SearchBar = (props: SearchProps) => {
+export const SplashPageSearchBar = (props: SearchProps) => {
   const [open, setOpen] = React.useState(false);
   const [options, setOptions] = React.useState<readonly Film[]>([]);
   const loading = open && options.length === 0;
@@ -82,14 +80,14 @@ export const SearchBar = (props: SearchProps) => {
 
   return (
     <>
-      <div className="text-primary w-11/12 h-fit flex flex-row items-center">
-        <div className="translate-x-12 w-8 h-8 text-primary">
+      <div className="text-primary m-auto w-11/12 -translate-y-1/2">
+        <div className="translate-y-10 translate-x-4 w-8 h-8 text-primary-light">
           <SearchIcon />
         </div>
         <Autocomplete
           multiple={true}
           disabled={props.disabled}
-          className="w-full h-12 bg-primary-light outline-0 active:outline-0 focus:outline-0 font-sans"
+          className="w-full h-12"
           open={open}
           onOpen={() => {
             setOpen(true);
@@ -120,48 +118,23 @@ export const SearchBar = (props: SearchProps) => {
             setInputValue(newInputValue);
           }}
           renderInput={(params) => (
-            <div
-              ref={params.InputProps.ref}
-              className="outline-0 active:outline-0 focus:outline-0 font-sans"
-            >
+            <div ref={params.InputProps.ref}>
               <input
                 {...params.inputProps}
                 type="search"
                 id="mainSearch"
-                className="outline-0 active:outline-0 focus:outline-0 w-full h-12 pl-16 bg-primary-light text-gray-600 placeholder-dark"
+                className="rounded-md border-primary-dark border-2 w-full h-12 pl-12 bg-white text-primary-dark placeholder-primary-dark font-bold"
                 placeholder="Search section number, professor name, course number...."
               />
             </div>
           )}
-          renderOption={(props, option, { selected }) => (
-            <li {...props} className="bg-white/25 my-4 mx-8 font-sans">
-              <Box className="text-lg text-gray-600">
-                {option.title}
-                <br />
-                <span className="text-base text-gray-600">{option.year}</span>
-              </Box>
-            </li>
-          )}
-          PopperComponent={(props) => {
-            return (
-              <Popper {...props} className="rounded-none" placement="bottom" />
-            );
-          }}
-          PaperComponent={({ children }) => {
-            return (
-              <Paper className="bg-primary-light rounded-none">
-                {children}
-              </Paper>
-            );
-          }}
           defaultValue={[]}
         />
-        <div className="w-8 h-8" />
       </div>
     </>
   );
 };
 
-SearchBar.defaultProps = {
+SplashPageSearchBar.defaultProps = {
   disabled: true,
 };

--- a/components/common/splashPageSearchBar.tsx
+++ b/components/common/splashPageSearchBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { SearchIcon } from './searchIcon';
 import Autocomplete from '@mui/material/Autocomplete';
-import { throttle } from 'lodash';
+import throttle from 'lodash/throttle';
 import topFilms from '../../data/autocomplete_dummy_data.json';
 
 /**
@@ -101,13 +101,21 @@ export const SplashPageSearchBar = (props: SearchProps) => {
           loading={loading}
           value={props.value}
           onChange={(event: any, newValue: Film[] | undefined) => {
-            let intersection = props.value
-              ? newValue
-                ? newValue.filter((x) => !props.value.includes(x))
-                : []
-              : newValue
-              ? newValue
-              : [];
+            let intersection: Film[];
+            if (props.value !== undefined) {
+              if (newValue !== undefined) {
+                // @ts-ignore
+                intersection = newValue.filter((x) => !props.value.includes(x));
+              } else {
+                intersection = [];
+              }
+            } else {
+              if (newValue !== undefined) {
+                intersection = newValue;
+              } else {
+                intersection = [];
+              }
+            }
             props.selectSearchValue(
               intersection[0] ? intersection[0].title : '',
             );

--- a/data/autocomplete_dummy_data.json
+++ b/data/autocomplete_dummy_data.json
@@ -1,0 +1,49 @@
+[
+  { "title": "The Shawshank Redemption", "year": 1994 },
+  { "title": "The Godfather", "year": 1972 },
+  { "title": "The Godfather: Part II", "year": 1974 },
+  { "title": "The Dark Knight", "year": 2008 },
+  { "title": "12 Angry Men", "year": 1957 },
+  { "title": "Schindler's List", "year": 1993 },
+  { "title": "Pulp Fiction", "year": 1994 },
+  {
+    "title": "The Lord of the Rings: The Return of the King",
+    "year": 2003
+  },
+  { "title": "The Good, the Bad and the Ugly", "year": 1966 },
+  { "title": "Fight Club", "year": 1999 },
+  {
+    "title": "The Lord of the Rings: The Fellowship of the Ring",
+    "year": 2001
+  },
+  {
+    "title": "Star Wars: Episode V - The Empire Strikes Back",
+    "year": 1980
+  },
+  { "title": "Forrest Gump", "year": 1994 },
+  { "title": "Inception", "year": 2010 },
+  {
+    "title": "The Lord of the Rings: The Two Towers",
+    "year": 2002
+  },
+  { "title": "One Flew Over the Cuckoo's Nest", "year": 1975 },
+  { "title": "Goodfellas", "year": 1990 },
+  { "title": "The Matrix", "year": 1999 },
+  { "title": "Seven Samurai", "year": 1954 },
+  {
+    "title": "Star Wars: Episode IV - A New Hope",
+    "year": 1977
+  },
+  { "title": "City of God", "year": 2002 },
+  { "title": "Se7en", "year": 1995 },
+  { "title": "The Silence of the Lambs", "year": 1991 },
+  { "title": "It's a Wonderful Life", "year": 1946 },
+  { "title": "Life Is Beautiful", "year": 1997 },
+  { "title": "The Usual Suspects", "year": 1995 },
+  { "title": "Léon: The Professional", "year": 1994 },
+  { "title": "Spirited Away", "year": 2001 },
+  { "title": "Saving Private Ryan", "year": 1998 },
+  { "title": "Once Upon a Time in the West", "year": 1968 },
+  { "title": "American History X", "year": 1998 },
+  { "title": "Interstellar", "year": 2014 }
+]

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@emotion/react": "^11.8.1",
     "@emotion/styled": "^11.6.0",
     "@material-ui/icons": "^4.11.2",
+    "@mui/icons-material": "^5.4.4",
     "@mui/material": "^5.4.2",
     "ansi-regex": "^6.0.1",
     "autoprefixer": "^10.4.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ansi-regex": "^6.0.1",
     "autoprefixer": "^10.4.2",
     "chart.js": "^3.7.1",
+    "lodash": "^4.17.21",
     "next": "12.1.0",
     "postcss": "^8.4.6",
     "react": "17.0.2",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "@commitlint/cli": "^16.2.1",
     "@commitlint/config-conventional": "^16.2.1",
+    "@types/lodash": "^4.14.179",
     "@types/node": "17.0.18",
     "@types/react": "17.0.39",
     "cz-conventional-changelog": "^3.0.1",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,8 @@
 import type { NextPage } from 'next';
 import Card from '@mui/material/Card';
-import { SearchBar } from '../components/common/searchBar';
+import { SplashPageSearchBar } from '../components/common/splashPageSearchBar';
 import { WaveSVG } from '../components/common/waveSVG';
 import { Wave2SVG } from '../components/common/wave2SVG';
-import { ExpandableSearchGrid } from '../components/common/expandableSearchGrid';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -50,21 +49,21 @@ const Home: NextPage = () => {
         <div className="w-full h-4/5 absolute translate-y-1/3 overflow-x-hidden overflow-hidden">
           <Wave2SVG />
         </div>
-        <ExpandableSearchGrid />
         <div className="flex justify-center content-center h-screen translate-y-">
           <div className="h-1/4 w-full relative m-auto">
             <Card className="bg-light relative sm:w-5/12 overflow-visible drop-shadow-lg rounded-xl bg-opacity-50 m-auto xs:w-11/12">
               <div className="bottom-0 absolute text-dark w-full h-1/4 m-auto pb-12 mt-4 mb-4">
-                <SearchBar
+                <SplashPageSearchBar
                   selectSearchValue={searchOptionChosen}
                   value={value}
                   setValue={setValue}
+                  disabled={false}
                 />
               </div>
               <div className="w-11/12 h-3/4 m-auto -translate-y-1/2 relative">
                 <Card className="bg-primary-dark rounded-xl drop-shadow-lg text-light p-8 relative h-full">
                   <div className="m-auto  w-1/5">
-                    <FlatLogoIcon/>
+                    <FlatLogoIcon />
                   </div>
                   <div className="text-center pb-2">
                     <h2 className="text-headline4">Welcome to Athena!</h2>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -43,10 +43,10 @@ const Home: NextPage = () => {
   return (
     <>
       <div className="w-full justify-center items-center bg-gradient-to-b from-primary to-light text-primary-darker ">
-        <div className="w-full h-4/5 absolute translate-y-1/4 overflow-x-hidden overflow-hidden">
+        <div className="w-full h-2/3 absolute translate-y-1/4 overflow-x-hidden overflow-hidden">
           <WaveSVG />
         </div>
-        <div className="w-full h-4/5 absolute translate-y-1/3 overflow-x-hidden overflow-hidden">
+        <div className="w-full h-2/3 absolute translate-y-1/3 overflow-x-hidden overflow-hidden">
           <Wave2SVG />
         </div>
         <div className="flex justify-center content-center h-screen translate-y-">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,9 @@
 import type { NextPage } from 'next';
 import Card from '@mui/material/Card';
-import styles from '../styles/Home.module.css';
-import VisualBubble from '../components/graph/visual-bubble';
 import { SearchBar } from '../components/common/searchBar';
 import { WaveSVG } from '../components/common/waveSVG';
 import { Wave2SVG } from '../components/common/wave2SVG';
-import router from 'next';
+import { ExpandableSearchGrid } from '../components/common/expandableSearchGrid';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -18,7 +16,6 @@ import {
 } from 'chart.js';
 import { FlatLogoIcon } from '../components/common/flatLogoIcon';
 import { useState } from 'react';
-import Head from 'next/head';
 ChartJS.register(
   CategoryScale,
   LinearScale,
@@ -29,30 +26,45 @@ ChartJS.register(
   Legend,
 );
 
+interface Film {
+  title: string;
+  year: number;
+}
+
 /**
  * Returns the home page with Nebula Branding, waved background, and SearchBar Components
-*/
+ */
 const Home: NextPage = () => {
-  const [searchVal, setSearchVal] = useState('');
+  const [value, setValue] = useState<Film[] | undefined>([]);
+
+  function searchOptionChosen(chosenOption: any) {
+    console.log('The option chosen was: ', chosenOption);
+  }
+
   return (
     <>
       <div className="w-full justify-center items-center bg-gradient-to-b from-primary to-light text-primary-darker ">
-        <div className="w-full h-2/3 absolute translate-y-1/4 overflow-x-hidden overflow-hidden">
+        <div className="w-full h-4/5 absolute translate-y-1/4 overflow-x-hidden overflow-hidden">
           <WaveSVG />
         </div>
-        <div className="w-full h-2/3 absolute translate-y-1/3 overflow-x-hidden overflow-hidden">
+        <div className="w-full h-4/5 absolute translate-y-1/3 overflow-x-hidden overflow-hidden">
           <Wave2SVG />
         </div>
+        <ExpandableSearchGrid />
         <div className="flex justify-center content-center h-screen translate-y-">
           <div className="h-1/4 w-full relative m-auto">
             <Card className="bg-light relative sm:w-5/12 overflow-visible drop-shadow-lg rounded-xl bg-opacity-50 m-auto xs:w-11/12">
               <div className="bottom-0 absolute text-dark w-full h-1/4 m-auto pb-12 mt-4 mb-4">
-                <SearchBar setSearch={setSearchVal} />
+                <SearchBar
+                  selectSearchValue={searchOptionChosen}
+                  value={value}
+                  setValue={setValue}
+                />
               </div>
               <div className="w-11/12 h-3/4 m-auto -translate-y-1/2 relative">
                 <Card className="bg-primary-dark rounded-xl drop-shadow-lg text-light p-8 relative h-full">
                   <div className="m-auto  w-1/5">
-                    <FlatLogoIcon></FlatLogoIcon>
+                    <FlatLogoIcon/>
                   </div>
                   <div className="text-center pb-2">
                     <h2 className="text-headline4">Welcome to Athena!</h2>


### PR DESCRIPTION
## Overview

Resolves #13 
Resolves #15 

This creates the ExpandableSearchGrid component, which will be used to add multiple search terms to the dashboard. This also includes the child components SearchTermCard and SearchBar (now separate from SplashPageSearchBar). From here, the calls to the API can be placed into the SearchBar component (and SplashPage variant) with little trouble.

## What Changed

The SearchBar now implements the Autocomplete component from Material-UI.
The SearchBar component is now solely used in the ExpandableSearchGrid, and the input on the splash page is referred to as SplashPageSearchBar, since the styling is significantly different between the two.

## Other Notes

The Autocomplete component currently refers to a JSON file of the Top 100 Films (used to test functionality). This will need to be replaced with the API call, and most of the groundwork is in-place already to do so.