### PR TITLE
Add tab nav bar so carousel can move between Grades and Detailed pages

### DIFF
--- a/components/common/carousel.tsx
+++ b/components/common/carousel.tsx
@@ -45,25 +45,17 @@ export const Carousel: FC<CarouselProps> = (props: CarouselProps) => {
   /**
    * Turn
    * This function slides the active component back and forth based upon whether it is fed a positive or negative value
-   * @param newDir a positive value will cause the card to move right, negative value cause card to move left
+   * @param displacement a positive value will cause the card to move right, negative value cause card to move left
    */
-  const turn = (newDir: number) => {
+  const turn = (displacement: number) => {
     //set direction
-    setDir(newDir);
-    //check for edges of arrayay
-    if (currentCard === 0 && newDir < 0) {
-      setCard(props.children.length - 1);
-    } else if (currentCard === props.children.length - 1 && newDir > 0) {
-      setCard(0);
-    } else {
-      //otherwise just add the direction (1 or -1 should be used for a single move)
-      setCard(currentCard + newDir);
-    }
+    setDir(displacement);
+    setCard(currentCard + displacement);
   };
 
   return (
     <>
-      <TabNavMenu value={currentCard} setValue={setCard}/>
+      <TabNavMenu value={currentCard} turner={turn}/>
       <div className="relative p-10 pt-0" style={{ height: '90%' }}>
         <AnimatePresence>
           <div className="h-full">

--- a/components/common/carousel.tsx
+++ b/components/common/carousel.tsx
@@ -1,9 +1,7 @@
 import { ReactJSXElement } from '@emotion/react/types/jsx-namespace';
-import { Button, Card } from '@mui/material';
 import React, { FC, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
-import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import {TabNavMenu} from "../navigation/tabNavMenu";
 
 type CarouselProps = {
   children: ReactJSXElement[];
@@ -65,7 +63,8 @@ export const Carousel: FC<CarouselProps> = (props: CarouselProps) => {
 
   return (
     <>
-      <div className="relative" style={{ height: '90%' }}>
+      <TabNavMenu value={currentCard} setValue={setCard}/>
+      <div className="relative p-10 pt-0" style={{ height: '90%' }}>
         <AnimatePresence>
           <div className="h-full">
             <motion.div

--- a/components/navigation/tabNavMenu.tsx
+++ b/components/navigation/tabNavMenu.tsx
@@ -1,20 +1,22 @@
-import {SyntheticEvent} from 'react';
 import {Divider, Tab, Tabs} from '@mui/material';
 
+/**
+ * Props type used by the TabNavMenu component
+ */
 type TabNavMenuProps = {
     value: number;
     setValue: Function;
 }
 
+/**
+ * This component returns a full-width bar with a Tabs component centered. There are two tabs, one for the Grades view
+ * and one for the Detailed view. This is connected to the parent component with the value and setValue functions,
+ * which are held by the parent and passed to this component to be manipulated by the Tabs component.
+ */
 export const TabNavMenu = (props: TabNavMenuProps) => {
-
-    const handleChange = (event: SyntheticEvent, newValue: number) => {
-        props.setValue(newValue);
-    };
-
     return (
-        <Tabs value={props.value} onChange={handleChange} aria-label="basic tabs example" centered
-              className="w-full min-h-[32px] grid grid-flow-row grid-cols-1 md:grid-flow-col justify-center shadow">
+        <Tabs value={props.value} onChange={(event, newValue) => props.setValue(newValue)} aria-label="basic tabs example" centered
+              className="w-full grid grid-flow-row justify-center shadow">
             <Tab label="Grades" className="text-lg text-gray-600 normal-case" value={0}/>
             <Tab label="" icon={<Divider orientation="vertical" />} disabled value={-1} className="w-px min-w-[1px]"/>
             <Tab label="Detailed" className="text-lg text-gray-600 normal-case" value={1}/>

--- a/components/navigation/tabNavMenu.tsx
+++ b/components/navigation/tabNavMenu.tsx
@@ -1,3 +1,4 @@
+import {SyntheticEvent} from 'react';
 import {Divider, Tab, Tabs} from '@mui/material';
 
 /**
@@ -5,7 +6,9 @@ import {Divider, Tab, Tabs} from '@mui/material';
  */
 type TabNavMenuProps = {
     value: number;
-    setValue: Function;
+    // Turning animation of the carousel is handled by the parent, and this method is
+    // responsible for playing the animation and setting the value to the correct new value
+    turner: Function;
 }
 
 /**
@@ -15,8 +18,13 @@ type TabNavMenuProps = {
  */
 export const TabNavMenu = (props: TabNavMenuProps) => {
     return (
-        <Tabs value={props.value} onChange={(event, newValue) => props.setValue(newValue)} aria-label="basic tabs example" centered
-              className="w-full grid grid-flow-row justify-center shadow">
+        <Tabs
+            value={props.value}
+            onChange={(event, newValue) => props.turner(newValue - props.value)}
+            aria-label="basic tabs example"
+            centered
+            className="w-full grid grid-flow-row justify-center shadow"
+        >
             <Tab label="Grades" className="text-lg text-gray-600 normal-case" value={0}/>
             <Tab label="" icon={<Divider orientation="vertical" />} disabled value={-1} className="w-px min-w-[1px]"/>
             <Tab label="Detailed" className="text-lg text-gray-600 normal-case" value={1}/>

--- a/components/navigation/tabNavMenu.tsx
+++ b/components/navigation/tabNavMenu.tsx
@@ -1,0 +1,23 @@
+import {SyntheticEvent} from 'react';
+import {Divider, Tab, Tabs} from '@mui/material';
+
+type TabNavMenuProps = {
+    value: number;
+    setValue: Function;
+}
+
+export const TabNavMenu = (props: TabNavMenuProps) => {
+
+    const handleChange = (event: SyntheticEvent, newValue: number) => {
+        props.setValue(newValue);
+    };
+
+    return (
+        <Tabs value={props.value} onChange={handleChange} aria-label="basic tabs example" centered
+              className="w-full min-h-[32px] grid grid-flow-row grid-cols-1 md:grid-flow-col justify-center shadow">
+            <Tab label="Grades" className="text-lg text-gray-600 normal-case" value={0}/>
+            <Tab label="" icon={<Divider orientation="vertical" />} disabled value={-1} className="w-px min-w-[1px]"/>
+            <Tab label="Detailed" className="text-lg text-gray-600 normal-case" value={1}/>
+        </Tabs>
+    );
+};

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -1,14 +1,8 @@
-import { Autocomplete, Input, Card } from '@mui/material';
+import { Card } from '@mui/material';
 import type { NextPage } from 'next';
-import { ReactNode, useState } from 'react';
+import { useState } from 'react';
 import Carousel from '../../components/common/carousel';
-import { SearchBar } from '../../components/common/searchBar';
-import { BarGraph } from '../../components/graph/BarGraph';
 import { GraphChoice } from '../../components/graph/GraphChoice';
-import { LineGraph } from '../../components/graph/LineGraph';
-import { RadarChart } from '../../components/graph/RadarChart';
-import { RadialBarChart } from '../../components/graph/RadialBarChart';
-import SearchGrid from '../../components/navigation/searchGrid';
 import TopMenu from '../../components/navigation/topMenu';
 import { ExpandableSearchGrid } from '../../components/common/expandableSearchGrid';
 
@@ -58,9 +52,9 @@ export const Dashboard: NextPage = () => {
     <>
       <div className="h-full lg:h-screen w-full bg-light">
         <TopMenu />
-        <ExpandableSearchGrid></ExpandableSearchGrid>
+        <ExpandableSearchGrid/>
         <div className="w-full h-5/6 justify-center">
-          <div className="w-full h-5/6 p-10 relative lg:min-h-full">
+          <div className="w-full h-5/6 relative lg:min-h-full">
             <Carousel>
               <div className="grid grid-cols-2 gap-4 p-4 h-full lg:grid-cols-4 ">
                 <Card className="row-span-4 col-span-2 p-4 h-screen lg:h-full">
@@ -69,7 +63,7 @@ export const Dashboard: NextPage = () => {
                     title="Grades Distribution"
                     labels={['Smith', 'Jason', 'Suzy']}
                     series={diffDat}
-                  ></GraphChoice>
+                  />
                 </Card>
                 <Card className="col-span-2 row-span-4 lg:row-span-2 p-4 h-screen lg:h-full">
                   <GraphChoice
@@ -77,7 +71,7 @@ export const Dashboard: NextPage = () => {
                     title="Grades Distribution"
                     xaxisLabels={['A', 'B', 'C', 'D', 'F', 'CR', 'NC']}
                     series={dat}
-                  ></GraphChoice>
+                  />
                 </Card>
                 <Card className="col-span-2 row-span-4 lg:row-span-2 p-4 h-screen lg:h-full">
                   <GraphChoice
@@ -85,7 +79,7 @@ export const Dashboard: NextPage = () => {
                     title="Class Averages"
                     xaxisLabels={['A', 'B', 'C', 'D', 'F', 'CR', 'NC']}
                     series={dat}
-                  ></GraphChoice>
+                  />
                 </Card>
               </div>
               <div className="grid grid-cols-1 gap-4 p-4 h-full sm:grid-cols-2 md:grid-cols-4">


### PR DESCRIPTION
## Overview

Closes #23, Closes #14 

Adds a tab navigation bar underneath the search grid in the dashboard for moving between the Grades and Detailed pages.

## What Changed

A tab navigation component has been created, using the Tabs component from Material-UI. This was added into the Carousel component, and the state of the page passed into it to be displayed and manipulated by the user.